### PR TITLE
Set next_page_token to None using MoreResults enum (#4347)

### DIFF
--- a/datastore/google/cloud/datastore/query.py
+++ b/datastore/google/cloud/datastore/query.py
@@ -27,9 +27,10 @@ from google.cloud.datastore.key import Key
 
 
 _NOT_FINISHED = _query_pb2.QueryResultBatch.NOT_FINISHED
+_NO_MORE_RESULTS = _query_pb2.QueryResultBatch.NO_MORE_RESULTS
 
 _FINISHED = (
-    _query_pb2.QueryResultBatch.NO_MORE_RESULTS,
+    _NO_MORE_RESULTS,
     _query_pb2.QueryResultBatch.MORE_RESULTS_AFTER_LIMIT,
     _query_pb2.QueryResultBatch.MORE_RESULTS_AFTER_CURSOR,
 )
@@ -454,7 +455,7 @@ class Iterator(page_iterator.Iterator):
         """
         self._skipped_results = response_pb.batch.skipped_results
 
-        if response_pb.batch.end_cursor == b'':  # Empty-value for bytes.
+        if response_pb.batch.more_results == _NO_MORE_RESULTS:
             self.next_page_token = None
         else:
             self.next_page_token = base64.urlsafe_b64encode(


### PR DESCRIPTION
Depending on empty value of ``response_pb.batch.end_cursor`` is not
reliable as the behaviour is not documented. It's better to check API
response field ``moreResults``, see
https://cloud.google.com/datastore/docs/reference/rpc/google.datastore.v1#google.datastore.v1.QueryResultBatch.